### PR TITLE
Enable the extension for the on-prem Server version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This extension can be found in the [Azure DevOps Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.cascading-picklists-extension 'Download Cascading Lists extension').
 
-Note that the extension is only supported on Azure DevOps Service. Is it is currently not supported on-prem yet due to a missing API.
-
 ## Cascading Picklists
 
 This extension uses the `ms.vss-work-web.work-item-form` contribution point that enables you to build a cascading picklist on the work item form. Cascading picklists are made up of two seperate fields. The parent field and a child field. The parent picklist will contain a list of values, that when a value is selected, will display the values in the child list.

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -25,7 +25,7 @@
   },
   "targets": [
     {
-      "id": "Microsoft.VisualStudio.Services.Cloud"
+      "id": "Microsoft.VisualStudio.Services"
     }
   ],
   "repository": {


### PR DESCRIPTION
This enables the extension for the Server version of Azure DevOps. I confirmed this extension works in Azure DevOps Server 2022. I might be able to check older versions, but I don't have any of those environments readily available.