### PR TITLE
Provide hints for the parent picklist value

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Once both picklists have been created and configured, you can configure what chi
 
 ![image](./images/settings-hub-1.png)
 
+You can also configure hints to pre-select the parent picklist value.
+The parent picklist value will be set based on the provided hint, if any, if it has no value when the form is shown.
+The only hint currently supported is `"Area Path"`.
+
 Config example:
 ```json
 {
@@ -27,6 +31,10 @@ Config example:
   "cascades": {
       "Custom.MajorRelease": {
           "Release Blue": {
+              "hint": {
+                  "when": "Area Path",
+                  "is": "My Project\\My Team"
+              },
               "Custom.MinorRelease": [
                   "Blue.1",
                   "Blue.2",
@@ -44,6 +52,8 @@ Config example:
   }
 }
 ```
+
+In the above example, if the Area Path of the work item is `"My Project\My Team"` or any child of that Area Path, the `Custom.MajorRelease` field will be preset to `"Release Blue"`.
 
 #### Tips
 

--- a/src/common/cascading.service.ts
+++ b/src/common/cascading.service.ts
@@ -13,7 +13,6 @@ import uniq from 'lodash/uniq';
 import {
   CascadeConfiguration,
   CascadeMap,
-  FieldHint,
   FieldOptions,
   FieldOptionsFlags,
   ICascade,

--- a/src/common/cascading.service.ts
+++ b/src/common/cascading.service.ts
@@ -17,6 +17,7 @@ import {
   FieldOptions,
   FieldOptionsFlags,
   ICascade,
+  RESERVED_FIELD_NAMES,
 } from './types';
 import { HintService } from './hints.service';
 
@@ -46,7 +47,7 @@ class CascadingFieldsService {
       let alters: string[] = [];
       Object.values(fieldValues).map(cascadeDefinitions => {
         Object.keys(cascadeDefinitions)
-          .filter(field => field !== 'hint')
+          .filter(field => !RESERVED_FIELD_NAMES.includes(field))
           .map(field => alters.push(field));
       });
 
@@ -67,7 +68,7 @@ class CascadingFieldsService {
       return [];
     }
     return Object.keys(this.cascadeMap[fieldReferenceName].cascades[fieldValue])
-      .filter(field => field !== 'hint');
+      .filter(field => !RESERVED_FIELD_NAMES.includes(field));
   }
 
   private async validateFilterOrClean(fieldReferenceName: string): Promise<boolean> {
@@ -183,7 +184,7 @@ class CascadeValidationService {
     Object.values(cascades).map(fieldValues => {
       Object.values(fieldValues).map(innerFields => {
         const invalidFields = Object.keys(innerFields)
-          .filter(field => field !== 'hint' && !fieldList.includes(field));
+          .filter(field => !RESERVED_FIELD_NAMES.includes(field) && !fieldList.includes(field));
         invalidFieldsTotal = [...invalidFieldsTotal, ...invalidFields];
       });
     });

--- a/src/common/cascading.service.ts
+++ b/src/common/cascading.service.ts
@@ -13,6 +13,7 @@ import uniq from 'lodash/uniq';
 import {
   CascadeConfiguration,
   CascadeMap,
+  FieldHint,
   FieldOptions,
   FieldOptionsFlags,
   ICascade,
@@ -41,7 +42,9 @@ class CascadingFieldsService {
     Object.entries(cascadeConfiguration).map(([fieldName, fieldValues]) => {
       let alters: string[] = [];
       Object.values(fieldValues).map(cascadeDefinitions => {
-        Object.keys(cascadeDefinitions).map(field => alters.push(field));
+        Object.keys(cascadeDefinitions)
+          .filter(field => field !== 'hint')
+          .map(field => alters.push(field));
       });
 
       alters = uniq(alters);
@@ -166,7 +169,8 @@ class CascadeValidationService {
     // Check fields on the lower level of config
     Object.values(cascades).map(fieldValues => {
       Object.values(fieldValues).map(innerFields => {
-        const invalidFields = Object.keys(innerFields).filter(field => !fieldList.includes(field));
+        const invalidFields = Object.keys(innerFields)
+          .filter(field => field !== 'hint' && !fieldList.includes(field));
         invalidFieldsTotal = [...invalidFieldsTotal, ...invalidFields];
       });
     });

--- a/src/common/hints.service.ts
+++ b/src/common/hints.service.ts
@@ -1,5 +1,5 @@
 import { IWorkItemFormService } from "azure-devops-extension-api/WorkItemTracking/WorkItemTrackingServices";
-import { CascadeMap } from "./types";
+import { CascadeMap, RESERVED_FIELD_NAMES } from "./types";
 
 export class HintService {
   private workItemService: IWorkItemFormService;
@@ -26,7 +26,7 @@ export class HintService {
         // Don't hint the parent field if any of the dependent fields have a
         // value, so that we don't clear out the existing value of the
         // dependent.
-        const dependentFieldRefs = Object.keys(cascade).filter(k => k !== 'hint');
+        const dependentFieldRefs = Object.keys(cascade).filter(k => !RESERVED_FIELD_NAMES.includes(k));
         const dependentFieldValues = await this.workItemService.getFieldValues(dependentFieldRefs);
         const dependentHasValue = Object.values(dependentFieldValues).some(v => !!v)
 

--- a/src/common/hints.service.ts
+++ b/src/common/hints.service.ts
@@ -1,0 +1,53 @@
+import { IWorkItemFormService } from "azure-devops-extension-api/WorkItemTracking/WorkItemTrackingServices";
+import { CascadeMap } from "./types";
+
+export class HintService {
+  private workItemService: IWorkItemFormService;
+  private isEnabled: boolean;
+
+  public constructor(workItemService: IWorkItemFormService) {
+    this.workItemService = workItemService
+    this.isEnabled = true
+  }
+
+  public setEnabled(isEnabled: boolean): void {
+    this.isEnabled = isEnabled
+  }
+
+  public async hintFieldValue(
+    cascadeMap: CascadeMap,
+    changedFieldReferenceName: string,
+    changedFieldValue: string
+  ): Promise<void> {
+    if (this.isEnabled && !changedFieldValue) {
+      for (const [option, cascade] of Object.entries(cascadeMap[changedFieldReferenceName].cascades)) {
+        if (!cascade.hint) continue;
+
+        // Don't hint the parent field if any of the dependent fields have a
+        // value, so that we don't clear out the existing value of the
+        // dependent.
+        const dependentFieldRefs = Object.keys(cascade).filter(k => k !== 'hint');
+        const dependentFieldValues = await this.workItemService.getFieldValues(dependentFieldRefs);
+        const dependentHasValue = Object.values(dependentFieldValues).some(v => !!v)
+
+        let shouldHint = false
+        if (!dependentHasValue) {
+          switch (cascade.hint.when) {
+            case 'Area Path':
+              shouldHint = await this.hintFromAreaPath(cascade.hint.is);
+              break;
+          }
+        }
+
+        if (shouldHint) {
+          await this.workItemService.setFieldValue(changedFieldReferenceName, option);
+        }
+      }
+    }
+  }
+
+  private async hintFromAreaPath(hint: string): Promise<boolean> {
+    const areaPath = await this.workItemService.getFieldValue('System.AreaPath') as string
+    return areaPath.startsWith(hint)
+  }
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,15 @@
 export type FieldName = string;
-export type FieldOptions = Record<FieldName, string[] | FieldOptionsFlags>;
+
+export const FIELD_HINT_SOURCES = ['Area Path'] as const;
+export type FieldHintSource = typeof FIELD_HINT_SOURCES[number];
+export type FieldHint = {
+  when: FieldHintSource,
+  is: string,
+};
+
+export type FieldOptions = {
+  hint?: FieldHint
+} & Record<FieldName, string[] | FieldOptionsFlags>;
 export type CascadeConfiguration = Record<FieldName, Record<FieldName, FieldOptions>>;
 export type CascadeMap = Record<FieldName, ICascade>;
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,9 @@
 export type FieldName = string;
 
+// A list of field names that are reserved for us. No valid field reference can
+// match these names.
+export const RESERVED_FIELD_NAMES: FieldName[] = ['hint']
+
 export const FIELD_HINT_SOURCES = ['Area Path'] as const;
 export type FieldHintSource = typeof FIELD_HINT_SOURCES[number];
 export type FieldHint = {


### PR DESCRIPTION
Allow users to configure hints to pre-populate the parent picklist value.

The only hint supported in the PR is "Area Path".

Future work could make this more generic, so that we can specify any field refname, along with options such as "equals" and "starts with" for comparing the field value to the hint.